### PR TITLE
Fixup Clojure collection tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,8 @@ TESTS = \
   test/lokke-scm-vector \
   test/metadata-handling \
   test/reader-basics \
-  test/clojure-fn
+  test/clojure-fn \
+  test/clojure-collection
 
 # FIXME...
 clean-local:

--- a/test/clojure-collection
+++ b/test/clojure-collection
@@ -55,3 +55,5 @@
 (testing "full sequential equals"
   (is (not (= '(1 2 3) '(4 5 6))))
   (is (not (= (seq [1 2 3]) [4 5 6]))))
+
+(end-tests (ns-name *ns*) :exit? true)


### PR DESCRIPTION
These tests weren't running before because they weren't in the
makefile. The tests were also missing the end-tests statement at the
end which would have caused them to fail if ran from the top level
test running (i.e. `make check`)