### PR TITLE
initial macOS support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,3 +27,33 @@ jobs:
       - run: git config --global user.email "you@example.com"
       - run: git config --global user.name "Your Name"
       - run: make -j4 check-everything
+  macos-guile-2:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - run: brew unlink guile
+      - run: ./dev/prep-for-macos-build guile@2
+      - run: echo "/usr/local/opt/guile@2/bin" >> $GITHUB_PATH
+      - run: test 2 = $(guile -c '(display (major-version))')
+      - run: echo "LDFLAGS=-L/usr/local/opt/guile@2/lib" >> $GITHUB_ENV
+      - run: echo "CPPFLAGS=-I/usr/local/opt/guile@2/include" >> $GITHUB_ENV
+      - run: echo "PKG_CONFIG_PATH=/usr/local/opt/guile@2/lib/pkgconfig" >> $GITHUB_ENV
+      - run: echo "ACLOCAL_PATH=/usr/local/opt/guile@2/share/aclocal" >> $GITHUB_ENV
+      - run: ./setup && autoreconf -fi && ./configure
+      - run: git config --global user.email "you@example.com"
+      - run: git config --global user.name "Your Name"
+      - run: make -j4 check-everything
+  macos-guile-3:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - run: ./dev/prep-for-macos-build guile
+      - run: test 3 = $(guile -c '(display (major-version))')
+      - run: ./setup && autoreconf -fi && ./configure
+      - run: git config --global user.email "you@example.com"
+      - run: git config --global user.name "Your Name"
+      - run: make -j4 check-everything

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Scheme-friendly, and possibly more efficient interface -- think
 most notable existing module is `(lokke scm vector)` which intends to
 provide a C backed implementation of Clojure's [persistent vectors](https://hypirion.com/musings/understanding-persistent-vector-pt-1).
 
-Getting started
----------------
+Pre-requisites
+--------------
 
 Currently Lokke can be found at
 [GitHub](https://github.com/lokke-org/lokke) and
@@ -64,10 +64,12 @@ To build Lokke, you'll need
   * [gettext](https://www.gnu.org/software/gettext/)
   * [git](https://git-scm.com/)
 
+## GNU/Linux
+
 Your system may already provide these.  For Debian, for example:
 
     # apt-get install autoconf automake libpcre2-dev libunistring-dev
-    # apt-get install  make gettext gcc git
+    # apt-get install make gettext gcc git
 
 and then for Guile 3.0:
 
@@ -77,10 +79,36 @@ or for Guile 2.2:
 
     # apt-get install guile-2.2 guile-2.2-dev
 
-and then:
+## macOS
 
-    $ git clone ... lokke
-    $ cd lokke
+For macOS you can use [Homebrew](https://brew.sh/) to install missing
+dependencies:
+
+    $ brew install autoconf automake pcre2 gettext git
+
+and then for Guile 3.0:
+
+    $ brew install guile
+
+or for Guile 2.2:
+
+    # Only if you have Guile 3.0 installed
+    $ brew unlink guile
+
+    $ brew install guile@2
+
+    # Setup environment variables as indicated after installation.
+    $ export PATH=/usr/local/opt/guile@2/bin:$PATH
+    $ export LDFLAGS=-L/usr/local/opt/guile@2/lib
+    $ export CPPFLAGS=-I/usr/local/opt/guile@2/include
+    $ export PKG_CONFIG_PATH=/usr/local/opt/guile@2/lib/pkgconfig
+    $ export ACLOCAL_PATH=/usr/local/opt/guile@2/share/aclocal
+
+Getting started
+---------------
+
+To build lokke follow these steps:
+
     $ ./setup
     $ autoreconf -fi
     $ ./configure
@@ -93,10 +121,9 @@ Hopefully the tests will pass.  If not, please report them to the
 fully supported, so depending on the host, something like `make -j5
 check` can be much faster.
 
-If you have more than one version of Guile installed, you may be able
-to select a particular version at configuration time like this:
-
-    $ ./configure GUILE_EFFECTIVE_VERSION=3.0
+If you have more than one version of Guile installed, we suggest to select it
+using your system tools (e.g. `update-alternatives` in Debian based systems or
+using the appropriate environment variables in macOS).
 
 At this point you should be able to run a Clojure program like this:
 

--- a/dev/prep-for-macos-build
+++ b/dev/prep-for-macos-build
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+usage()
+{
+    echo "Usage: prep-for-macos-build [guile@2 | guile]"
+}
+
+guile="${1:-guile}"
+formulae='autoconf automake pcre2 gettext git'
+
+case "$guile" in
+    guile@2|guile)
+        brew install $formulae $guile
+        ;;
+    *)
+        usage 1>&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
Initial macOS support with as minimum changes as I could.

* README.md: The way to change from guile-3.0 to guile-2.2 depends on the system (use `update-alternatives` in Debian, or set the right PATH in macOS).

* dev/prep-for-macos-build: install macOS dependencies through Homebrew.

* added github actions for macos.